### PR TITLE
Add JIRA(atlassian) format link copy function

### DIFF
--- a/src/copy.js
+++ b/src/copy.js
@@ -39,6 +39,17 @@ function copyurlAsMarkdown() {
   });
 }
 
+function copyurlAsJiraFormat() {
+  chrome.tabs.getSelected(this.jstdata, function(tab) {
+    if( tab.title ){
+      copyToClipboard('['+tab.title+'|'+tab.url+']');
+    } else {
+      copyToClipboard( '['+tab.url+']' );
+    }
+    window.close();
+  });
+}
+
 function copytitleurl() {
   chrome.tabs.getSelected(this.jstdata, function(tab) {
     if( tab.title ){
@@ -104,8 +115,10 @@ function copyurlwtag() {
 document.addEventListener('DOMContentLoaded', function () {
     document.getElementById('copyurl').addEventListener('click', copyurl);
     document.getElementById('copyurlAsMarkdown').addEventListener('click', copyurlAsMarkdown);
+    document.getElementById('copyurlAsJiraFormat').addEventListener('click', copyurlAsJiraFormat);
     document.getElementById('copytitleurl').addEventListener('click', copytitleurl);
     document.getElementById('copytitleurlshorten').addEventListener('click', copytitleurlshorten);
+
     document.getElementById('copyTitleUrlWithTag').addEventListener('click', copyurlwtag);
 })
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -27,6 +27,7 @@
 <body>
   <div id="copyurl">URL</div>
   <div id="copyurlAsMarkdown">Markdown Link</div>
+  <div id="copyurlAsJiraFormat">JIRA Link</div>
   <div id="copytitleurl">Title : URL</div>
   <div id="copytitleurlshorten">Title : short <img src="indicator.white.gif" id="indicator" style="visibility: hidden;"></div>
   <div id="copyurlwtag">&lt;a href= &gt;Tag</div>


### PR DESCRIPTION
hi Mr. ldong.

I always use the extensions conveniently.
I wanted to use JIRA's link creation function,
 so I will send you a PullRequest with additional functions.

[Text Formatting Notation Help - Create and track feature requests for Atlassian products.](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=links)