### PR TITLE
Fix DomElementName for html tag

### DIFF
--- a/src/copy.js
+++ b/src/copy.js
@@ -90,7 +90,7 @@ function copyselectiontitleshorten(selection) {
   });
 }
 
-function copyurlwtag() {
+function copyTitleUrlWithTag() {
   chrome.tabs.getSelected(this.jstdata,function(tab) {
     if( tab.title ){
       copyToClipboard( "<a href=\"" + tab.url + "\" >" + tab.title + "</a>" );
@@ -106,7 +106,7 @@ document.addEventListener('DOMContentLoaded', function () {
     document.getElementById('copyurlAsMarkdown').addEventListener('click', copyurlAsMarkdown);
     document.getElementById('copytitleurl').addEventListener('click', copytitleurl);
     document.getElementById('copytitleurlshorten').addEventListener('click', copytitleurlshorten);
-    document.getElementById('copyTitleUrlWithTag').addEventListener('click', copyurlwtag);
+    document.getElementById('copyTitleUrlWithTag').addEventListener('click', copyTitleUrlWithTag);
 })
 
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -29,7 +29,7 @@
   <div id="copyurlAsMarkdown">Markdown Link</div>
   <div id="copytitleurl">Title : URL</div>
   <div id="copytitleurlshorten">Title : short <img src="indicator.white.gif" id="indicator" style="visibility: hidden;"></div>
-  <div id="copyurlwtag">&lt;a href= &gt;Tag</div>
+  <div id="copyTitleUrlWithTag">&lt;a href= &gt;Tag</div>
   <textarea id="hbnaclhngkhpmpgmfakaghgjbblokeeh" value=""></textarea>
 
   <script type="text/javascript" src="googl.js"></script>


### PR DESCRIPTION
hi Mr. ldong.

Fix for wrong DOMElement name.
It was in the store reviews.

[Copy Url Title to clipboard - Chrome ウェブストア](https://chrome.google.com/webstore/detail/copy-url-title-to-clipboa/fphedfdnajgljnfadpekgjglaemgkfgb)